### PR TITLE
Support 4sq trigger word

### DIFF
--- a/src/foursquare-locator.coffee
+++ b/src/foursquare-locator.coffee
@@ -39,14 +39,14 @@ module.exports = (robot) ->
   foursquare = require('node-foursquare')(config);
 
   # Default action
-  robot.respond /(foursquare|swarm)$/i, (msg) ->
+  robot.respond /(foursquare|4sq|swarm)$/i, (msg) ->
     if missingEnvironmentForApi(msg)
       return
 
     friendActivity(msg)
 
   # Who are my friends?
-  robot.respond /(foursquare|swarm) friends/i, (msg) ->
+  robot.respond /(foursquare|4sq|swarm) friends/i, (msg) ->
 
     if missingEnvironmentForApi(msg)
       return
@@ -65,7 +65,7 @@ module.exports = (robot) ->
         msg.send "Your bot has no friends. :("
 
   # Approve pending bot friend requests
-  robot.respond /(foursquare|swarm) approve/i, (msg) ->
+  robot.respond /(foursquare|4sq|swarm) approve/i, (msg) ->
 
     if missingEnvironmentForApi(msg)
       return
@@ -85,7 +85,7 @@ module.exports = (robot) ->
         msg.send "No friend requests to approve."
 
   # Tell people how to friend the bot
-  robot.respond /(foursquare|swarm) register/i, (msg) ->
+  robot.respond /(foursquare|4sq|swarm) register/i, (msg) ->
 
     if missingEnvironmentForApi(msg)
       return
@@ -97,7 +97,7 @@ module.exports = (robot) ->
       msg.send response.user.bio if response.user.bio?
 
   # Identify your username with the bot
-  robot.respond /(foursquare|swarm) ([a-zA-Z0-9]+) as ([0-9]+)/i, (msg) ->
+  robot.respond /(foursquare|4sq|swarm) ([a-zA-Z0-9]+) as ([0-9]+)/i, (msg) ->
     if msg.match[1] is 'me'
       actor = msg.message.user.name
     else
@@ -117,7 +117,7 @@ module.exports = (robot) ->
     msg.send "Ok, I have #{actor} as #{user_id} on Foursquare."
 
   # Stop remembering a particular username
-  robot.respond /(foursquare|swarm) forget ([a-zA-Z0-9]+)/i, (msg) ->
+  robot.respond /(foursquare|4sq|swarm) forget ([a-zA-Z0-9]+)/i, (msg) ->
 
     actor = msg.match[1].trim()
 

--- a/test/foursquare-locator_test.coffee
+++ b/test/foursquare-locator_test.coffee
@@ -19,19 +19,19 @@ describe 'foursquare-locator', ->
     require('../src/foursquare-locator')(@robot)
 
   it 'registers a respond listener for friends', ->
-    expect(@robot.respond).to.have.been.calledWith(/(foursquare|swarm) friends/i)
+    expect(@robot.respond).to.have.been.calledWith(/(foursquare|4sq|swarm) friends/i)
 
   it 'registers a respond listener for approve', ->
-    expect(@robot.respond).to.have.been.calledWith(/(foursquare|swarm) approve/i)
+    expect(@robot.respond).to.have.been.calledWith(/(foursquare|4sq|swarm) approve/i)
 
   it 'registers a respond listener for register', ->
-    expect(@robot.respond).to.have.been.calledWith(/(foursquare|swarm) register/i)
+    expect(@robot.respond).to.have.been.calledWith(/(foursquare|4sq|swarm) register/i)
 
   it 'registers a respond listener for mapping user as ID', ->
-    expect(@robot.respond).to.have.been.calledWith(/(foursquare|swarm) ([a-zA-Z0-9]+) as ([0-9]+)/i)
+    expect(@robot.respond).to.have.been.calledWith(/(foursquare|4sq|swarm) ([a-zA-Z0-9]+) as ([0-9]+)/i)
 
   it 'registers a respond listener for forgetting a user', ->
-    expect(@robot.respond).to.have.been.calledWith(/(foursquare|swarm) forget ([a-zA-Z0-9]+)/i)
+    expect(@robot.respond).to.have.been.calledWith(/(foursquare|4sq|swarm) forget ([a-zA-Z0-9]+)/i)
 
   it 'registers a hear listener', ->
     expect(@robot.respond).to.have.been.calledWith(/where[ ']i?s ([a-zA-Z0-9 ]+)(\?)?$/i)


### PR DESCRIPTION
This will allow users to prefix commands with `4sq` as well as `foursquare` and `swarm`
