### PR TITLE
Initialize the brain before using it

### DIFF
--- a/src/foursquare-locator.coffee
+++ b/src/foursquare-locator.coffee
@@ -36,6 +36,8 @@ module.exports = (robot) ->
     redirectUrl: "localhost"
   config.version = '20140401'
 
+  robot.brain.data.foursquare or= {}
+
   foursquare = require('node-foursquare')(config);
 
   # Default action


### PR DESCRIPTION
I just started creating hubot scripts today, so I'm not really sure if this is the right approach, but I got the error below while using this script. It seems that the hash `robot.brain.data.foursquare` isn't initialized and indeed I cannot find any place in the code where this should happen. I've looked in other scripts and it seems that you should initialize it first - after making this change the foursquare script works - but again, I have no idea what I'm doing here ;)

```
Hubot> hubot where is bob?
[Mon Dec 22 2014 01:39:33 GMT+0100 (CET)] ERROR TypeError: Cannot read property 'bob' of undefined
  at TextListener.callback (/Users/watson/code/node_modules/hubot-foursquare-locator/src/foursquare-locator.coffee:143:5, <js>:123:45)
  at TextListener.Listener.call (/Users/watson/code/champion/piwi/node_modules/hubot/src/listener.coffee:27:7, <js>:23:14)
  at Robot.receive (/Users/watson/code/champion/piwi/node_modules/hubot/src/robot.coffee:197:9, <js>:142:33)
  at Shell.Adapter.receive (/Users/watson/code/champion/piwi/node_modules/hubot/src/adapter.coffee:66:5, <js>:47:25)
  at Interface.<anonymous> (/Users/watson/code/champion/piwi/node_modules/hubot/src/adapters/shell.coffee:56:15, <js>:100:23)
  at Interface.emit (events.js:95:17)
  at Interface._onLine (readline.js:202:10)
  at Interface._line (readline.js:531:8)
  at Interface._ttyWrite (readline.js:760:14)
  at ReadStream.onkeypress (readline.js:99:10)
  at ReadStream.emit (events.js:98:17)
  at emitKey (readline.js:1095:12)
  at ReadStream.onData (readline.js:840:14)
  at ReadStream.emit (events.js:95:17)
  at ReadStream.<anonymous> (_stream_readable.js:764:14)
  at ReadStream.emit (events.js:92:17)
  at emitReadable_ (_stream_readable.js:426:10)
  at emitReadable (_stream_readable.js:422:5)
  at readableAddChunk (_stream_readable.js:165:9)
  at ReadStream.Readable.push (_stream_readable.js:127:10)
  at TTY.onread (net.js:528:21)
```
