### PR TITLE
Bump version in package-lock.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,8 @@ module.exports = function (grunt) {
     release: {
       options: {
         tagName: 'v<%= version %>',
-        commitMessage: 'Prepared to release <%= version %>.'
+        commitMessage: 'Prepared to release <%= version %>.',
+        additionalFiles: ['package-lock.json']
       }
     },
     watch: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-foursquare-locator",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -97,7 +97,8 @@
     "async": {
       "version": "0.1.22",
       "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE="
+      "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+      "dev": true
     },
     "atob": {
       "version": "2.0.3",
@@ -212,9 +213,9 @@
       }
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "builtin-modules": {
@@ -365,9 +366,9 @@
       }
     },
     "colors": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
       "version": "1.0.5",
@@ -1813,6 +1814,11 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "js-yaml": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
@@ -2115,15 +2121,15 @@
       }
     },
     "mocha": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.1.tgz",
-      "integrity": "sha512-SpwyojlnE/WRBNGtvJSNfllfm5PqEDFxcWluSIgLeSBJtXG4DmoX2NNAeEA7rP5kK+79VgtVq8nG6HskaL1ykg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.3.tgz",
+      "integrity": "sha512-oi0ylWkmIR+IG8OcQkLGPMWhxu/Gfz9EBW7Mztr6FY4JbrPDDi5y9rb2ncNnajZtr2XHfBP+G5pzS6gEzdAcVQ==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
+        "browser-stdout": "1.3.1",
         "commander": "2.11.0",
         "debug": "3.1.0",
-        "diff": "3.3.1",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
         "growl": "1.10.3",
@@ -2146,6 +2152,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
         },
         "glob": {
           "version": "7.1.2",
@@ -2179,9 +2191,9 @@
       }
     },
     "moment": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
-      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA=="
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "morgan": {
       "version": "1.6.1",
@@ -2333,11 +2345,11 @@
       }
     },
     "node-foursquare": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/node-foursquare/-/node-foursquare-0.3.0.tgz",
-      "integrity": "sha1-LMvssq5vYEAXRZMCaVv62jd6/e8=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/node-foursquare/-/node-foursquare-0.3.2.tgz",
+      "integrity": "sha512-6ywGKrWGm80XcJIoxGcdH/nudJ1QNHfIqHoGvIyp05zESU/BqK+qGQZtpvpXrI9uCrl41xr1ikFXFWr/4JKptA==",
       "requires": {
-        "winston": "0.6.2"
+        "winston": "2.4.0"
       }
     },
     "nopt": {
@@ -2578,11 +2590,6 @@
         "pinkie": "2.0.4"
       }
     },
-    "pkginfo": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
-      "integrity": "sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg="
-    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -2741,11 +2748,6 @@
       "requires": {
         "is-finite": "1.0.2"
       }
-    },
-    "request": {
-      "version": "2.9.203",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.9.203.tgz",
-      "integrity": "sha1-bBcRpUB/uUoRQhlWPkQUW8v0cjo="
     },
     "resolve": {
       "version": "1.1.7",
@@ -3008,9 +3010,9 @@
       }
     },
     "sinon-chai": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
-      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.0.0.tgz",
+      "integrity": "sha512-+cqeKiuMZjZs800fRf4kjJR/Pp4p7bYY3ciZHClFNS8tSzJoAcWni/ZUZD8TrfZ+oFRyLiKWX3fTClDATGy5vQ==",
       "dev": true
     },
     "snapdragon": {
@@ -3617,17 +3619,23 @@
       }
     },
     "winston": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-0.6.2.tgz",
-      "integrity": "sha1-QUT+JYbNwZphK/jANVkBMskGS9I=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
       "requires": {
-        "async": "0.1.22",
-        "colors": "0.6.2",
+        "async": "1.0.0",
+        "colors": "1.0.3",
         "cycle": "1.0.3",
         "eyes": "0.1.8",
-        "pkginfo": "0.2.3",
-        "request": "2.9.203",
+        "isstream": "0.1.2",
         "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+        }
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "hubot": ">=2"
   },
   "dependencies": {
-    "moment": "~2.19.2",
-    "node-foursquare": "0.3.0"
+    "moment": "~2.21.0",
+    "node-foursquare": "0.3.2"
   },
   "devDependencies": {
     "chai": "^4.1.2",
@@ -37,10 +37,10 @@
     "hubot-test-helper": "^1.8.1",
     "husky": "^0.14.3",
     "matchdep": "~2.0.0",
-    "mocha": "^5.0.1",
-    "nock": "^9.1.6",
-    "sinon": "^4.3.0",
-    "sinon-chai": "^2.14.0"
+    "mocha": "^5.0.3",
+    "nock": "^9.2.3",
+    "sinon": "^4.4.2",
+    "sinon-chai": "^3.0.0"
   },
   "main": "index.coffee",
   "scripts": {

--- a/src/foursquare-locator.coffee
+++ b/src/foursquare-locator.coffee
@@ -36,7 +36,9 @@ module.exports = (robot) ->
     clientSecret: process.env.FOURSQUARE_CLIENT_SECRET
     accessToken: process.env.FOURSQUARE_ACCESS_TOKEN
     redirectUrl: "localhost"
-  config.version = '20180302'
+  config.foursquare =
+    mode: 'foursquare',
+    version: '20140806'
   config.winston =
     loggers:
       core:


### PR DESCRIPTION
- Attempted to handle this in #10, apparently didn't bump them far enough.
- `grunt release:<major|minor|patch>` process will also bump the `package-lock.json` file.
- Fixed a warning about version usage.